### PR TITLE
Update for outgoing domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ your deployed app is installed, use the following command (once again, replacing
 $ slack env add GITHUB_TOKEN ACCESS_TOKEN
 ```
 
+## Configure outgoing domains
+
+Hosted custom functions must declare which
+[outgoing domains](https://api.slack.com/future/manifest) are used when making
+network requests, including Github API calls. `api.github.com` is already
+configured as an outgoing domain in this sample's manifest. If your organization
+uses a separate Github Enterprise to make API calls to, add that domain to the
+`outgoingDomains` array in `manifest.ts`.
+
 ## Create a Link Trigger
 
 [Triggers](https://api.slack.com/future/triggers) are what cause Workflows to

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Slack using functions and workflows.
   - [Install the Slack CLI](#install-the-slack-cli)
   - [Clone the Sample App](#clone-the-sample-app)
   - [GitHub Access Token](#github-access-token)
+  - [Configure Outgoing Domains](#configure-outgoing-domains)
 - [Create a Link Trigger](#create-a-link-trigger)
 - [Running Your Project Locally](#running-your-project-locally)
 - [Deploying Your App](#deploying-your-app)
@@ -103,7 +104,7 @@ your deployed app is installed, use the following command (once again, replacing
 $ slack env add GITHUB_TOKEN ACCESS_TOKEN
 ```
 
-## Configure outgoing domains
+### Configure Outgoing Domains
 
 Hosted custom functions must declare which
 [outgoing domains](https://api.slack.com/future/manifest) are used when making

--- a/manifest.ts
+++ b/manifest.ts
@@ -8,6 +8,8 @@ export default Manifest({
   icon: "assets/icon.png",
   functions: [CreateIssueDefinition],
   workflows: [CreateNewIssueWorkflow],
-  outgoingDomains: [],
+  // If your organizaiton uses a separate Github enterprise domain, add that domain to this list
+  // so that functions can make API calls to it.
+  outgoingDomains: ["api.github.com"],
   botScopes: ["commands", "chat:write", "chat:write.public"],
 });

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.3.0/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.7.0/mod.ts"
   }
 }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Adds documentation for how to use this sample properly setting outgoingDomains for Github Enterprise users, and adds `api.github.com` to outgoingDomains for plain GH.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
