### PR TITLE
Send GitHub API versioning in request header

### DIFF
--- a/functions/create_issue/mod.ts
+++ b/functions/create_issue/mod.ts
@@ -9,6 +9,7 @@ export default SlackFunction(
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${env.GITHUB_TOKEN}`,
       "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
     };
 
     const { url, title, description, assignees } = inputs;


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

For a stable experience with the GitHub API, this PR adds the `X-GitHub-Api-Version: 2022-11-28` header to requests sent to GitHub. This change was made following [this announcement](https://github.blog/2022-11-28-to-infinity-and-beyond-enabling-the-future-of-githubs-rest-api-with-api-versioning/#i-have-an-existing-integration-with-the-rest-api-what-does-this-mean-for-me) of GitHub's new versioning scheme.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
