### PR TITLE
Add nullable flag to property with custom type

### DIFF
--- a/functions/create_issue.ts
+++ b/functions/create_issue.ts
@@ -1,9 +1,5 @@
-import {
-  DefineFunction,
-  DefineProperty,
-  Schema,
-  SlackFunction,
-} from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { GitHubIssueCustomType } from "./types.ts";
 
 /**
  * Functions are reusable building blocks of automation that accept inputs,
@@ -30,24 +26,9 @@ export const CreateIssueDefinition = DefineFunction({
        * Custom objects can be wrapped with the DefineProperty function for
        * strong typing when using these objects in the function handler.
        */
-      githubIssue: DefineProperty({
-        type: Schema.types.object,
-        properties: {
-          title: {
-            type: Schema.types.string,
-            description: "Issue Title",
-          },
-          description: {
-            type: Schema.types.string,
-            description: "Issue Description",
-          },
-          assignees: {
-            type: Schema.types.string,
-            description: "Assignees",
-          },
-        },
-        required: ["title"],
-      }),
+      githubIssue: {
+        type: GitHubIssueCustomType,
+      },
     },
     required: ["githubAccessTokenId", "url", "githubIssue"],
   },

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -1,0 +1,29 @@
+import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
+
+/**
+ * This is a Slack Custom type for an Announcement
+ * For more on defining Custom types:
+ *
+ * https://api.slack.com/future/types/custom
+ */
+export const GitHubIssueCustomType = DefineType({
+  name: "GitHubIssue",
+  type: Schema.types.object,
+  properties: {
+    title: {
+      type: Schema.types.string,
+      description: "Issue Title",
+    },
+    description: {
+      type: Schema.types.string,
+      description: "Issue Description",
+      nullable: true,
+    },
+    assignees: {
+      type: Schema.types.string,
+      description: "Assignees",
+      nullable: true,
+    },
+  },
+  required: ["title"],
+});

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,5 +1,6 @@
 import { Manifest } from "deno-slack-sdk/mod.ts";
 import GitHubProvider from "./external_auth/github_provider.ts";
+import { GitHubIssueCustomType } from "./functions/types.ts";
 import CreateNewIssueWorkflow from "./workflows/create_new_issue.ts";
 
 /**
@@ -13,6 +14,7 @@ export default Manifest({
   icon: "assets/default_new_app_icon.png",
   externalAuthProviders: [GitHubProvider],
   workflows: [CreateNewIssueWorkflow],
+  types: [GitHubIssueCustomType],
   /**
    * Domains used in remote HTTP requests must be specified as outgoing domains.
    * If your organization uses a seperate GitHub Enterprise domain, add it here


### PR DESCRIPTION
### Description

If a property is listed as neither required nor nullable (this situation), the key does not have to be present, but if it is, its value cannot be null, in this app, we send `description` and `assignee` in the payload always but not necessarily have value. This PR will fix this problem

### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Describe the goal of this PR. Mention any related Issue numbers. 

If you are introducing a new sample app in this pull request, please also include a detailed description of the application’s purpose and functionality.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
