### PR TITLE
Replace `/future` links with `/automation`

### DIFF
--- a/external_auth/github_provider.ts
+++ b/external_auth/github_provider.ts
@@ -4,7 +4,7 @@ import { DefineOAuth2Provider, Schema } from "deno-slack-sdk/mod.ts";
  * External authentication uses the OAuth 2.0 protocol to connect with
  * accounts across various services. Once authenticated, an access token
  * can be used to interact with the service on behalf of the user.
- * Learn more: https://api.slack.com/future/external-auth
+ * Learn more: https://api.slack.com/automation/external-auth
  */
 
 // https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow

--- a/functions/create_issue.ts
+++ b/functions/create_issue.ts
@@ -9,7 +9,7 @@ import {
  * Functions are reusable building blocks of automation that accept inputs,
  * perform calculations, and provide outputs. Functions can be used as steps in
  * a workflow or independently.
- * Learn more: https://api.slack.com/future/functions/custom
+ * Learn more: https://api.slack.com/automation/functions/custom
  */
 export const CreateIssueDefinition = DefineFunction({
   callback_id: "create_issue",

--- a/manifest.ts
+++ b/manifest.ts
@@ -5,7 +5,7 @@ import CreateNewIssueWorkflow from "./workflows/create_new_issue.ts";
 /**
  * The app manifest contains the app's configuration. This file defines
  * attributes like app name, description, available workflows, and more.
- * Learn more: https://api.slack.com/future/manifest
+ * Learn more: https://api.slack.com/automation/manifest
  */
 export default Manifest({
   name: "Workflows for GitHub",

--- a/triggers/create_new_issue_shortcut.ts
+++ b/triggers/create_new_issue_shortcut.ts
@@ -4,7 +4,7 @@ import CreateNewIssueWorkflow from "../workflows/create_new_issue.ts";
 /**
  * Triggers determine when workflows are executed. A trigger file describes a
  * scenario in which a workflow should be run, such as a user clicking a link.
- * Learn more: https://api.slack.com/future/triggers/link
+ * Learn more: https://api.slack.com/automation/triggers/link
  */
 const createNewIssueShortcut: Trigger<
   typeof CreateNewIssueWorkflow.definition

--- a/workflows/create_new_issue.ts
+++ b/workflows/create_new_issue.ts
@@ -4,7 +4,7 @@ import { CreateIssueDefinition } from "../functions/create_issue.ts";
 /**
  * A workflow is a set of steps that are executed in order. Each step in a
  * workflow is a function – either a built-in or custom function.
- * Learn more: https://api.slack.com/future/workflows
+ * Learn more: https://api.slack.com/automation/workflows
  */
 const CreateNewIssueWorkflow = DefineWorkflow({
   callback_id: "create_new_issue_workflow",
@@ -14,7 +14,7 @@ const CreateNewIssueWorkflow = DefineWorkflow({
     properties: {
       /**
        * This workflow users interactivity to collect input from the user.
-       * Learn more: https://api.slack.com/future/forms#add-interactivity
+       * Learn more: https://api.slack.com/automation/forms#add-interactivity
        */
       interactivity: {
         type: Schema.slack.types.interactivity,
@@ -30,7 +30,7 @@ const CreateNewIssueWorkflow = DefineWorkflow({
 /**
  * Collecting input from users can be done with the built-in OpenForm function
  * as the first step.
- * Learn more: https://api.slack.com/future/functions#open-a-form
+ * Learn more: https://api.slack.com/automation/functions#open-a-form
  */
 const issueFormData = CreateNewIssueWorkflow.addStep(
   Schema.slack.functions.OpenForm,
@@ -70,13 +70,13 @@ const issueFormData = CreateNewIssueWorkflow.addStep(
  * A custom function can be added as a workflow step to modify input data,
  * interact with an external API, and return responses from the API for use in
  * later steps.
- * Learn more: https://api.slack.com/future/functions/custom
+ * Learn more: https://api.slack.com/automation/functions/custom
  */
 const issue = CreateNewIssueWorkflow.addStep(CreateIssueDefinition, {
   /**
    * The credential source defines which external authentication tokens are
    * passed to the function. These are automatically injected at runtime.
-   * Learn more: https://api.slack.com/future/external-auth#workflow
+   * Learn more: https://api.slack.com/automation/external-auth#workflow
    */
   githubAccessTokenId: {
     credential_source: "DEVELOPER",
@@ -91,7 +91,7 @@ const issue = CreateNewIssueWorkflow.addStep(CreateIssueDefinition, {
 
 /**
  * Messages can be sent into a channel with the built-in SendMessage function.
- * Learn more: https://api.slack.com/future/functions#send-message
+ * Learn more: https://api.slack.com/automation/functions#catalog
  */
 CreateNewIssueWorkflow.addStep(Schema.slack.functions.SendMessage, {
   channel_id: CreateNewIssueWorkflow.inputs.channel,


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR updates links pointing to `api.slack.com/future/*` to `api.slack.com/automation/*` to avoid any unnecessary redirects. Updates to links in the `README` are contained in #22 and so are omitted here.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
