### PR TITLE
Expanding deno.jsonc

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,17 @@
 {
+  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
+  "fmt": {
+    "files": {
+      "include": ["README.md", "datastores", "functions", "manifest.ts", "triggers", "workflows"]
+    }
+  },
   "importMap": "import_map.json",
+  "lint": {
+    "files": {
+      "include": ["datastores", "functions", "manifest.ts", "triggers", "workflows"]
+    }
+  },
+  "lock": false,
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
   }


### PR DESCRIPTION
Include specific files and directories when linting/formatting, disable lock file usage and creation.

I found my local `deno task test` execution was failing 'cause Deno was trying to format my e.g. `.slack/apps.dev.json` file, or other unrelated files.