### PR TITLE
Fixes #33 Remove github issue object

### DIFF
--- a/functions/create_issue.ts
+++ b/functions/create_issue.ts
@@ -1,9 +1,4 @@
-import {
-  DefineFunction,
-  DefineProperty,
-  Schema,
-  SlackFunction,
-} from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
 
 /**
  * Functions are reusable building blocks of automation that accept inputs,
@@ -26,30 +21,26 @@ export const CreateIssueDefinition = DefineFunction({
         type: Schema.types.string,
         description: "Repository URL",
       },
-      /**
-       * Custom objects can be wrapped with the DefineProperty function for
-       * strong typing when using these objects in the function handler.
-       */
-      githubIssue: DefineProperty({
-        type: Schema.types.object,
-        properties: {
-          title: {
-            type: Schema.types.string,
-            description: "Issue Title",
-          },
-          description: {
-            type: Schema.types.string,
-            description: "Issue Description",
-          },
-          assignees: {
-            type: Schema.types.string,
-            description: "Assignees",
-          },
-        },
-        required: ["title", "description", "assignees"],
-      }),
+      title: {
+        type: Schema.types.string,
+        description: "Issue Title",
+      },
+      description: {
+        type: Schema.types.string,
+        description: "Issue Description",
+      },
+      assignees: {
+        type: Schema.types.string,
+        description: "Assignees",
+      },
     },
-    required: ["githubAccessTokenId", "url", "githubIssue"],
+    required: [
+      "githubAccessTokenId",
+      "url",
+      "title",
+      "description",
+      "assignees",
+    ],
   },
   output_parameters: {
     properties: {
@@ -91,8 +82,7 @@ export default SlackFunction(
       "X-GitHub-Api-Version": "2022-11-28",
     };
 
-    const { url, githubIssue } = inputs;
-    const { title, description, assignees } = githubIssue;
+    const { url, title, description, assignees } = inputs;
 
     try {
       const { hostname, pathname } = new URL(url);

--- a/functions/create_issue_test.ts
+++ b/functions/create_issue_test.ts
@@ -34,11 +34,9 @@ Deno.test("Create a GitHub issue with given inputs", async () => {
   const inputs = {
     githubAccessTokenId: {},
     url: "https://github.com/slack-samples/deno-github-functions",
-    githubIssue: {
-      title: "The issue title",
-      description: "issue description",
-      assignees: "batman",
-    },
+    title: "The issue title",
+    description: "issue description",
+    assignees: "batman",
   };
   const { outputs } = await handler(createContext({ inputs, env }));
   assertEquals(outputs?.GitHubIssueNumber, 123);

--- a/workflows/create_new_issue.ts
+++ b/workflows/create_new_issue.ts
@@ -82,11 +82,9 @@ const issue = CreateNewIssueWorkflow.addStep(CreateIssueDefinition, {
     credential_source: "DEVELOPER",
   },
   url: issueFormData.outputs.fields.url,
-  githubIssue: {
-    title: issueFormData.outputs.fields.title,
-    description: issueFormData.outputs.fields.description,
-    assignees: issueFormData.outputs.fields.assignees,
-  },
+  title: issueFormData.outputs.fields.title,
+  description: issueFormData.outputs.fields.description,
+  assignees: issueFormData.outputs.fields.assignees,
 });
 
 /**


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Fixes #33. Removes the githubIssue object so that the fields show up within the Workflow Builder UI. There may be a better way to improve this but just throwing this out there! 

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
