### PR TITLE
Add extra select-auth step

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ the GitHub account you want to authenticate with:
 $ slack external-auth add
 ```
 
+After you've added your authentication, you'll need to select it using the following command.
+
+```zsh
+$ slack external-auth select-auth
+```
+
 Once you've successfully connected your account, you're almost ready to create a
 link into your workflow!
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ the GitHub account you want to authenticate with:
 $ slack external-auth add
 ```
 
-After you've added your authentication, you'll need to select it using the following command.
+After you've added your authentication, you'll need to assign it to the
+`#/workflows/create_new_issue_workflow` workflow using the following command:
 
 ```zsh
 $ slack external-auth select-auth


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

As of v2.3.0, after using the `slack external-auth add` command, you need to use the `slack external-auth select-auth` command if `credential_source: "DEVELOPER"`.  Adding this into the instructions since the instructions error out without this at the moment.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
