### PR TITLE
Note the requirement to grant access to orgs when authorizing the OAuth app

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ the GitHub account you want to authenticate with:
 $ slack external-auth add
 ```
 
-**Note: when working with repositories that are part of an organization, be sure to grant access to
-that organization when authorizing your OAuth app.**
+**Note: when working with repositories that are part of an organization, be sure
+to grant access to that organization when authorizing your OAuth app.**
 
 After you've added your authentication, you'll need to assign it to the
 `#/workflows/create_new_issue_workflow` workflow using the following command:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ the GitHub account you want to authenticate with:
 $ slack external-auth add
 ```
 
+To access repositories in an organization from a workflow, also grant access to
+the organization when authorizing your OAuth app.
+
 After you've added your authentication, you'll need to assign it to the
 `#/workflows/create_new_issue_workflow` workflow using the following command:
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ the GitHub account you want to authenticate with:
 $ slack external-auth add
 ```
 
-To access repositories in an organization from a workflow, also grant access to
-the organization when authorizing your OAuth app.
+**Note: when working with repositories that are part of an organization, be sure to grant access to
+that organization when authorizing your OAuth app.**
 
 After you've added your authentication, you'll need to assign it to the
 `#/workflows/create_new_issue_workflow` workflow using the following command:


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR adds a clarifying note that access to an organization might be required when using workflows with these organizations. Related to #45.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
