### PR TITLE
Prefer optional and formatted values in the "Create issue" form

### DIFF
--- a/functions/create_issue.ts
+++ b/functions/create_issue.ts
@@ -38,8 +38,6 @@ export const CreateIssueDefinition = DefineFunction({
       "githubAccessTokenId",
       "url",
       "title",
-      "description",
-      "assignees",
     ],
   },
   output_parameters: {

--- a/workflows/create_new_issue.ts
+++ b/workflows/create_new_issue.ts
@@ -62,7 +62,7 @@ const issueFormData = CreateNewIssueWorkflow.addStep(
           "GitHub username(s) of the user(s) to assign the issue to (separated by commas)",
         type: Schema.types.string,
       }],
-      required: ["url", "title", "description", "assignees"],
+      required: ["url", "title"],
     },
   },
 );

--- a/workflows/create_new_issue.ts
+++ b/workflows/create_new_issue.ts
@@ -45,6 +45,7 @@ const issueFormData = CreateNewIssueWorkflow.addStep(
         title: "Repository URL",
         description: "The GitHub URL of the repository",
         type: Schema.types.string,
+        format: "url",
       }, {
         name: "title",
         title: "Issue title",


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR adds the `url` format to the "Create issue" form and no longer requires the `description` and `assignee` values since [these are optional](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue) for the API.

### Reviewers

Either test this updated workflow or confirm this created issue looks good – zimeg/slack-sandbox#49.

Note: The optional fields were previously reverted due to #18 but this seems to be fixed now!

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
