### PR TITLE
fix: post the created issue link with mrkdwn formatting

### DIFF
--- a/workflows/create_new_issue.ts
+++ b/workflows/create_new_issue.ts
@@ -96,7 +96,7 @@ CreateNewIssueWorkflow.addStep(Schema.slack.functions.SendMessage, {
   channel_id: CreateNewIssueWorkflow.inputs.channel,
   message:
     `Issue #${issue.outputs.GitHubIssueNumber} has been successfully created\n` +
-    `Link to issue: ${issue.outputs.GitHubIssueLink}`,
+    `Link to issue: <${issue.outputs.GitHubIssueLink}>`,
 });
 
 export default CreateNewIssueWorkflow;


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR fixes #66 by wrapping the created issue link in `mrkdwn` formatting!

Reference: https://api.slack.com/reference/surfaces/formatting#linking-urls

### Preview

This snapshot shows an issue created before and after changes:

![issues](https://github.com/user-attachments/assets/2391c097-0dc1-4387-a631-b53a1b764a7b)

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
