### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
 
     "@std/dotenv": "jsr:@std/dotenv@^0.225.5",
     "@std/testing": "jsr:@std/testing@^1.0.16",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,8 +30,9 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+
     "@std/dotenv": "jsr:@std/dotenv@^0.225.5",
     "@std/testing": "jsr:@std/testing@^1.0.16",
     "@std/assert": "jsr:@std/assert@^1.0.15"

--- a/external_auth/github_provider.ts
+++ b/external_auth/github_provider.ts
@@ -1,4 +1,4 @@
-import { DefineOAuth2Provider, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineOAuth2Provider, Schema } from "@slack/sdk";
 import "@std/dotenv/load";
 
 /**

--- a/functions/create_issue.ts
+++ b/functions/create_issue.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 
 /**
  * Functions are reusable building blocks of automation that accept inputs,

--- a/functions/create_issue_test.ts
+++ b/functions/create_issue_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { stub } from "@std/testing/mock";
 
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import handler from "./create_issue.ts";
 
 /**

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import GitHubProvider from "./external_auth/github_provider.ts";
 import CreateNewIssueWorkflow from "./workflows/create_new_issue.ts";
 

--- a/triggers/create_new_issue_shortcut.ts
+++ b/triggers/create_new_issue_shortcut.ts
@@ -1,5 +1,5 @@
-import type { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import type { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import CreateNewIssueWorkflow from "../workflows/create_new_issue.ts";
 
 /**

--- a/workflows/create_new_issue.ts
+++ b/workflows/create_new_issue.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { CreateIssueDefinition } from "../functions/create_issue.ts";
 
 /**


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)